### PR TITLE
move notifications from tab bar to home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,8 @@ const AnalyticsTracker = () => {
 };
 
 const App: React.FC = () => {
-  const { notifications, removeNotification } = useNotifications();
+  const { notifications, removeNotification, notificationPermission } =
+    useNotifications();
   useEffect(() => {
     SplashScreen.hide();
   }, []);
@@ -161,6 +162,7 @@ const App: React.FC = () => {
                 <Home
                   notifications={notifications}
                   removeNotification={removeNotification}
+                  notificationPermission={notificationPermission}
                 />
               </Route>
               <Route exact path="/login" component={Login} />
@@ -216,13 +218,6 @@ const App: React.FC = () => {
               <IonTabButton tab="schedule" href="/schedule">
                 <IonIcon aria-hidden="true" icon={calendar} />
                 <IonLabel>Schedule</IonLabel>
-              </IonTabButton>
-              <IonTabButton tab="notifcations" href="/notifications">
-                <IonIcon icon={alarm} />
-                {notifications.length > 0 && (
-                  <IonBadge color="danger">{notifications.length}</IonBadge>
-                )}
-                <IonLabel>Notifications </IonLabel>
               </IonTabButton>
             </IonTabBar>
           </IonTabs>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,6 +22,7 @@ import {
   IonGrid,
   IonRow,
   IonCol,
+  IonBadge,
 } from '@ionic/react';
 import {
   personCircleOutline,
@@ -29,6 +30,8 @@ import {
   timeOutline,
   flagOutline,
   closeOutline,
+  notificationsOff,
+  notifications as notificationsIcon,
 } from 'ionicons/icons';
 import { PushNotificationSchema } from '@capacitor/push-notifications';
 import StokeMeter from '../components/StokeMeter';
@@ -70,6 +73,7 @@ const getIconForNotification = (notification: PushNotificationSchema) => {
 interface HomeProps {
   notifications: PushNotificationSchema[];
   removeNotification: (notifcation: PushNotificationSchema) => void;
+  notificationPermission: PermissionState;
 }
 
 interface FireDBDynamicContent {
@@ -86,7 +90,11 @@ interface FireDBDynamicContent {
   id: string;
 }
 
-const Home: React.FC<HomeProps> = ({ notifications, removeNotification }) => {
+const Home: React.FC<HomeProps> = ({
+  notifications,
+  removeNotification,
+  notificationPermission,
+}) => {
   const router = useIonRouter();
 
   const { data, loading, error, refetch } =
@@ -143,6 +151,18 @@ const Home: React.FC<HomeProps> = ({ notifications, removeNotification }) => {
           <IonToolbar color={'primary'}>
             <IonTitle>Oak City Shred Fest 5</IonTitle>
             <IonButtons slot="end">
+              <IonButton routerLink="/notifications">
+                <IonIcon
+                  icon={
+                    notificationPermission === 'granted'
+                      ? notificationsIcon
+                      : notificationsOff
+                  }
+                />
+                {notifications.length > 0 && (
+                  <IonBadge color="danger">{notifications.length}</IonBadge>
+                )}
+              </IonButton>
               <IonButton routerLink="/login">
                 <IonIcon icon={personCircleOutline} size="large" />
               </IonButton>
@@ -168,6 +188,29 @@ const Home: React.FC<HomeProps> = ({ notifications, removeNotification }) => {
           <IonGrid>
             <IonRow>
               {/* active notifications */}
+              {notificationPermission !== 'granted' &&
+                Capacitor.isNativePlatform() && (
+                  <IonCol
+                    size={colSize}
+                    sizeLg={colSizeLg}
+                    key={'notifications_disabled'}
+                  >
+                    <IonCard className="ion-padding">
+                      <IonList>
+                        <IonItem>
+                          <IonIcon icon={notificationsOff} slot="start" />
+                          <IonLabel>
+                            <h2>Notifications Disabled</h2>
+                            <p>
+                              Enable notifcations in your system settings to
+                              receive updates.
+                            </p>
+                          </IonLabel>
+                        </IonItem>
+                      </IonList>
+                    </IonCard>
+                  </IonCol>
+                )}
               {notifications.length > 0 && (
                 <IonCol size={colSize} sizeLg={colSizeLg} key={1}>
                   <IonCard className="ion-padding">

--- a/src/pages/Racing.css
+++ b/src/pages/Racing.css
@@ -65,9 +65,9 @@ ion-card-title {
 }
 
 .hero-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  width: 100%; /* Ensures responsiveness on mobile */
+  height: auto; /* Maintains aspect ratio */
+  display: block; /* Removes any default inline spacing */
 }
 
 .hero-overlay {
@@ -76,7 +76,7 @@ ion-card-title {
   right: 0;
   width: 33.333%;
   height: 100%;
-  background: linear-gradient(to left, rgba(0, 0, 0, 0.7), transparent);
+  background: linear-gradient(to left, rgba(0, 0, 0, 0.9), transparent);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -90,4 +90,23 @@ ion-card-title {
   font-size: 1.25rem;
   font-weight: bold;
   margin-bottom: 0.5rem;
+}
+
+/* Media query for larger screens */
+@media (min-width: 768px) {
+  /* Adjust breakpoint as needed */
+  .hero-section {
+    max-width: 800px; /* Limits the container width on large screens */
+    margin-left: auto;
+    margin-right: auto; /* Centers the section */
+  }
+
+  .hero-image {
+    max-height: 600px; /* Limits the height on large screens */
+    object-fit: cover; /* Ensures the image crops nicely if needed */
+  }
+
+  .hero-overlay {
+    width: 33.333%; /* Keeps the overlay proportional */
+  }
 }

--- a/src/pages/TicketsPage.tsx
+++ b/src/pages/TicketsPage.tsx
@@ -66,7 +66,7 @@ const TicketsPage: React.FC = () => {
 
   return (
     <IonPage>
-      <PageHeader title="Schedule" />
+      <PageHeader title="Tickets" />
 
       <IonContent className="ion-padding">
         {loading ? (


### PR DESCRIPTION
- move notifications from tab bar to home page
- indicate whether notifications are enabled
- show message on native platforms if notifications are disabled 
- fix Ticket Page title bar
- make racing page show up a little better on large screens