### PR TITLE
feat(home): modify home page content to be data driven by DynamicContent data

### DIFF
--- a/src/components/DynamicContent.tsx
+++ b/src/components/DynamicContent.tsx
@@ -12,13 +12,16 @@ import {
 import { useState } from 'react';
 import { chevronDown, chevronForward } from 'ionicons/icons';
 import dayjs from 'dayjs';
+import { h } from 'ionicons/dist/types/stencil-public-runtime';
 
 export interface DynamicContentProps {
+  id: string;
+  contentType: string;
   enabled: boolean;
   imageLink: string;
   title: string;
   subtitle: string;
-  datePosted: string;
+  datePosted: Date;
   shortDescription: string;
   detailedImageLink: string;
   detailedDescription: string;
@@ -45,7 +48,7 @@ const DynamicContent: React.FC<DynamicContentProps> = ({
   };
 
   return (
-    <IonCard style={{ marginTop: '0', marginBottom: '16px' }}>
+    <IonCard style={{ marginTop: '0', marginBottom: '0px', height: '100%' }}>
       {imageLink && <IonImg src={imageLink} onClick={onToggleView} />}
       <IonCardHeader onClick={onToggleView}>
         {title && <IonCardTitle>{title}</IonCardTitle>}

--- a/src/components/FoodTruckSwiper.module.css
+++ b/src/components/FoodTruckSwiper.module.css
@@ -5,8 +5,8 @@
 }
 
 .container {
-  margin-bottom: 8px;
-  margin-top: 8px;
+  margin-bottom: 0px;
+  margin-top: 0px;
 }
 
 .header {

--- a/src/components/NextEvent.tsx
+++ b/src/components/NextEvent.tsx
@@ -34,10 +34,6 @@ const NextEvent: React.FC<NextEventProps> = ({
     }).format(date);
   }
 
-  if (loading || error || upcomingEvents.length < 1) {
-    return null;
-  }
-
   const nextEvent = upcomingEvents[0];
   const eventStartDateTime = new Date(nextEvent.start.dateTime);
   const month = eventStartDateTime.toLocaleString('default', {

--- a/src/components/OutdatedVersionNotice.tsx
+++ b/src/components/OutdatedVersionNotice.tsx
@@ -6,11 +6,13 @@ import styles from './OutdatedVersionNotice.module.css';
 interface OutdatedVersionNoticeProps {
   currentVersion: string;
   minVersion: string;
-  loading: boolean;
-  error?: string;
 }
 
-const isVersionOutdated = (current: string, minimum: string): boolean => {
+export const isVersionOutdated = (
+  current: string,
+  minimum: string
+): boolean => {
+  if (current === '0.0.0' || minimum === '0.0.0') return false;
   const normalize = (v: string) => v.split('.').map(Number);
   const [cMajor, cMinor, cPatch] = normalize(current);
   const [mMajor, mMinor, mPatch] = normalize(minimum);
@@ -24,15 +26,8 @@ const isVersionOutdated = (current: string, minimum: string): boolean => {
 const OutdatedVersionNotice: React.FC<OutdatedVersionNoticeProps> = ({
   currentVersion,
   minVersion,
-  loading,
-  error,
 }) => {
-  if (loading || error || currentVersion === '0.0.0' || minVersion === '0.0.0')
-    return null;
-
-  const outdated = isVersionOutdated(currentVersion, minVersion);
-
-  return outdated ? (
+  return (
     <IonCard color="warning" className="ion-margin">
       <IonCardContent className={styles.warningContent}>
         <IonIcon icon={warningOutline} className={styles.icon} />
@@ -44,7 +39,7 @@ const OutdatedVersionNotice: React.FC<OutdatedVersionNoticeProps> = ({
         </IonText>
       </IonCardContent>
     </IonCard>
-  ) : null;
+  );
 };
 
 export default OutdatedVersionNotice;


### PR DESCRIPTION
## 🧠 Summary

Content on the home page (like food trucks, featured competitor, upcoming event, ticket counter, etc) can now be controlled using the DynamicContent data collection in Firebase.  An admin can now control the visibility of these items and their placement relative to other items on the home page.



New data fields for DynamicContent include contentType which should contain one of the following hard-coded values:

- DYNAMIC
- NEXT_EVENT
- FOOD_TRUCK_SWIPER
- FEATURED_COMPETITOR
- STOKE_METER
- TICKET_COUNTER
- COUNTDOWN

Closes #396

---

## 📝 Notes

There are also some changes to improve spacing between cards including moving visibility logic for components out of components and into the parent (Home).
